### PR TITLE
Ensure viewId is incremented at end only

### DIFF
--- a/src/videotracker.js
+++ b/src/videotracker.js
@@ -501,7 +501,6 @@ class VideoTracker extends Tracker {
    */
   sendRequest (att) {
     if (this.state.goRequest()) {
-      this.state.goViewCountUp()
       let ev = this.isAd() ? VideoTracker.Events.AD_REQUEST : VideoTracker.Events.CONTENT_REQUEST
       this.send(ev, att)
       this.startHeartbeat()

--- a/test/videotracker.spec.js
+++ b/test/videotracker.spec.js
@@ -18,6 +18,22 @@ describe('VideoTracker', () => {
     Log.level = Log.Levels.ERROR
   })
 
+  describe('viewId', () => {
+    let tracker, adTracker
+  
+    it('should be incremented after sendEnd', () => {
+      tracker = new VideoTracker(1)
+  
+      tracker.sendCustom('test')
+      expect(tracker.getViewId().slice(-1)).to.be.equal('0')
+      tracker.sendRequest()
+      expect(tracker.getViewId().slice(-1)).to.be.equal('0')
+      tracker.sendStart()
+      tracker.sendEnd()
+      expect(tracker.getViewId().slice(-1)).to.be.equal('1')
+    })
+  })
+
   describe('settings', () => {
     it('should set options', () => {
       tracker = new VideoTracker(1, { isAd: true, tag: 2 })


### PR DESCRIPTION
## 📄 Description

`viewId` is extrapolated out of the `viewSessionId` by appending an incremented integer to it to isolate subsequent playback within the same tracker.

All is good until consumer of the library uses custom events prior to the initial play event of their video player. This causes custom events to be reported under `viewId-0` while the rest of the playback events will be stored under `viewId-1`.

## ⛑️  Fix

By simply not incrementing the `viewId` during `sendRequest`, we end up having the expected behavior where all events are stored under the same `viewId`.

## 📓 Notes

I had to change a few things in the tests to actually run the newly added tests around `viewId`. I believe the project has not been thoroughly maintained and would probably need a spring cleanup. :)

## 🖼️ Results

Example of our 3 custom events sent in our projet:

![Screenshot 2023-05-19 at 11 54 55 AM](https://github.com/newrelic/video-core-js/assets/513491/1ca6ae18-f39f-4952-9a15-f3c41cecef98)

