### PR TITLE
Permit `deviceType` to be set by `tracker.customData`

### DIFF
--- a/src/plugins/nrinsightsbackend.js
+++ b/src/plugins/nrinsightsbackend.js
@@ -105,12 +105,14 @@ class NRInsightsBackend extends Backend {
         else if (navigator.userAgent.indexOf("Opera") != -1 ) agentName = "Opera"
         data['userAgentName'] = agentName
 
-        let deviceType = "Unknown"
-        if (navigator.userAgent.match(/Tablet|iPad/i)) deviceType = "Tablet"
-        else if (navigator.userAgent.match(/Mobile|Windows Phone|Lumia|Android|webOS|iPhone|iPod|Blackberry|PlayBook|BB10|Opera Mini|\bCrMo\/|Opera Mobi/i)) deviceType = "Mobile"
-        else if (window.cast != undefined) deviceType = "Cast"
-        else deviceType = "Desktop"
-        data['deviceType'] = deviceType
+        if (!data['deviceType']) {
+            let deviceType = "Unknown"
+            if (navigator.userAgent.match(/Tablet|iPad/i)) deviceType = "Tablet"
+            else if (navigator.userAgent.match(/Mobile|Windows Phone|Lumia|Android|webOS|iPhone|iPod|Blackberry|PlayBook|BB10|Opera Mini|\bCrMo\/|Opera Mobi/i)) deviceType = "Mobile"
+            else if (window.cast != undefined) deviceType = "Cast"
+            else deviceType = "Desktop"
+            data['deviceType'] = deviceType
+        }
 
         return data
     }


### PR DESCRIPTION
Previously `tracker.customData.deviceType` would always be overwritten.