### PR TITLE
feat: add setPlayer method to VideoTracker mock for shared repos compatibility

### DIFF
--- a/__mock__.js
+++ b/__mock__.js
@@ -58,6 +58,12 @@ const nrvideo = {
     sendRenditionChanged() {}
     setAdsTracker() {}
     getTrackerVersion() { return '1.0.0'; }
+
+    // Added for consumer repository compatibility
+    setPlayer(player, tag) {
+      this.player = player;
+      this.tag = tag || player;
+    }
   },
 
   /**


### PR DESCRIPTION
File: `__mock__.js`
Addition: `setPlayer(player, tag)` method to VideoTracker class
Purpose: Ensures compatibility when Shaka and other consumer repos use shared video-core mock

Shaka tracker calls `nrvideo.VideoTracker.prototype.setPlayer.call(this, player, tag)` which requires this method to exist in the parent class mock. Without this method, Shaka tests fail with "Cannot read properties of undefined (reading 'call')".
## Consumer Repository Impact
This change enables all video repositories to use the shared mock approach:
- **Shaka**:   59/59 tests passing
- **Video.js**:  447/447 tests passing  
- **Bitmovin**: 82/82 tests passing
- 
## Next Steps
After this merges and is published,  repositories can update their Jest configurations to point to the shared mock, completely eliminating duplicate mock files and manual synchronization work.
