### PR TITLE
fix/update-module-resolution

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
   "presets": ["@babel/preset-env"],
-  "plugins": ["@babel/plugin-transform-modules-commonjs"]
+  "plugins": []
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [4.1.5-beta] - 2025/01/19
+
+### Fix
+
+- update configs for correct module resolution for consumer
+
 ## [4.1.1-beta] - 2025/12/19
 
 ## Fix

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/video-core",
-  "version": "4.1.5-beta",
+  "version": "4.1.6-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/video-core",
-      "version": "4.1.5-beta",
+      "version": "4.1.6-beta",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.24.5",
@@ -80,6 +80,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -1901,6 +1902,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1924,6 +1926,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6006,6 +6009,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6066,6 +6070,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6779,6 +6784,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -11053,6 +11059,7 @@
       "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
@@ -14460,6 +14467,7 @@
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -14509,6 +14517,7 @@
       "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/video-core",
-  "version": "4.1.5-beta",
+  "version": "4.1.6-beta",
   "description": "New Relic video tracking core library",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ const nrvideo = {
   version,
 
   // Enhanced video analytics components (new)
-
+ 
   NrVideoEventAggregator,
   RetryQueueHandler,
   OptimizedHttpClient,
@@ -38,24 +38,6 @@ const nrvideo = {
   recordEvent,
 
 
-};
-
-// Named exports for better tree-shaking and interop
-export {
-  Core,
-  Constants,
-  Chrono,
-  Log,
-  Emitter,
-  Tracker,
-  VideoTracker,
-  VideoTrackerState,
-  NrVideoEventAggregator,
-  RetryQueueHandler,
-  OptimizedHttpClient,
-  HarvestScheduler,
-  recordEvent,
-  version
 };
 
 export default nrvideo;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,6 +22,7 @@ module.exports = [
       filename: "nrvideo" + ".min.js",
       library: "nrvideo",
       libraryTarget: "umd",
+      libraryExport: "default",
     },
     devtool: "source-map",
     module: {


### PR DESCRIPTION
 Root Cause

  The .babelrc file contained @babel/plugin-transform-modules-commonjs, which transformed ES6 modules to CommonJS before webpack could process them. This caused a double-transformation issue:

  1. Babel transformed export default nrvideo → exports.default = nrvideo
  2. Webpack received already-transformed CommonJS code
  3. Webpack's libraryExport: "default" option failed because it expected ES6 module syntax
  4. Result: Incorrect export structure → module.exports.nrvideo = {...} instead of module.exports = {...}

  When video-html5-js imported the package, it received a nested structure where nrvideo.VideoTracker was undefined.

  Solution

  Removed @babel/plugin-transform-modules-commonjs from .babelrc:

   {
     "presets": ["@babel/preset-env"],
  -  "plugins": ["@babel/plugin-transform-modules-commonjs"]
   }

  This allows webpack to handle module transformations (its specialty) while Babel continues to transform other modern JavaScript syntax for browser compatibility.

  Technical Details

  - Webpack natively supports ES6 modules and has better optimization capabilities (tree-shaking, dead code elimination)
  - The libraryExport: "default" option in webpack.config.js now works correctly
  - Module transformations should be handled by webpack, not Babel, in webpack-based projects
  - This is the recommended approach per Babel and webpack documentation