### PR TITLE
fix: Drop bitrate attributes before start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [4.0.3] - 2026/01/29
+
+### Fix
+
+- **Drop bitrate values before start**
+  Modified `getAttributes()` in `videotracker.js` to check `this.state.isStarted` before adding bitrate attributes
+
 ## [4.1.0-beta] - 2025/12/18
 
 ### Feature
 
 - Add QOE KPIs attributes for VideoAction event with updated DATAMODEL.md
 
-## [4.0.3] - 2025/11/03
+## [4.0.2] - 2025/11/03
 
 ### Chore
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/video-core",
-  "version": "3.1.1",
+  "version": "4.1.0-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/video-core",
-      "version": "3.1.1",
+      "version": "4.1.0-beta",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.24.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/video-core",
-  "version": "4.1.0-beta",
+  "version": "4.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/video-core",
-      "version": "4.1.0-beta",
+      "version": "4.0.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.24.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/video-core",
-  "version": "4.1.0-beta",
+  "version": "4.0.3",
   "description": "New Relic video tracking core library",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/src/videotracker.js
+++ b/src/videotracker.js
@@ -465,12 +465,17 @@ class VideoTracker extends Tracker {
       att.adTitle = this.getTitle();
       att.adSrc = this.getSrc();
       att.adCdn = this.getCdn();
-      att.adBitrate =
-        this.getBitrate() ||
-        this.getWebkitBitrate() ||
-        this.getRenditionBitrate();
+
+      // Only add bitrate attributes after ad has started
+      if (this.state.isStarted) {
+        att.adBitrate =
+          this.getBitrate() ||
+          this.getWebkitBitrate() ||
+          this.getRenditionBitrate();
+        att.adRenditionBitrate = this.getRenditionBitrate();
+      }
+
       att.adRenditionName = this.getRenditionName();
-      att.adRenditionBitrate = this.getRenditionBitrate();
       att.adRenditionHeight = this.getRenditionHeight();
       att.adRenditionWidth = this.getRenditionWidth();
       att.adDuration = this.getDuration();
@@ -492,13 +497,17 @@ class VideoTracker extends Tracker {
       att.contentPlayhead = this.getPlayhead();
 
       att.contentIsLive = this.isLive();
-      att.contentBitrate =
-        this.getBitrate() ||
-        this.getWebkitBitrate() ||
-        this.getRenditionBitrate();
+
+      // Only add bitrate attributes after content has started
+      if (this.state.isStarted) {
+        att.contentBitrate =
+          this.getBitrate() ||
+          this.getWebkitBitrate() ||
+          this.getRenditionBitrate();
+        att.contentRenditionBitrate = this.getRenditionBitrate();
+      }
 
       att.contentRenditionName = this.getRenditionName();
-      att.contentRenditionBitrate = this.getRenditionBitrate();
       att.contentRenditionHeight = this.getRenditionHeight();
       att.contentRenditionWidth = this.getRenditionWidth();
       att.contentDuration = this.getDuration();

--- a/test/videotracker.spec.js
+++ b/test/videotracker.spec.js
@@ -91,6 +91,75 @@ describe("VideoTracker", () => {
       tag.webkitVideoDecodedByteCount += 3000;
       expect(tracker.getWebkitBitrate()).to.equal(800);
     });
+
+    it("should drop bitrate attributes before content start", () => {
+      // Setup jsdom environment
+      const dom = new JSDOM("<!doctype html><html><body></body></html>");
+      global.window = dom.window;
+      global.document = dom.window.document;
+
+      tracker = new VideoTracker();
+
+      // Mock getBitrate to return a value
+      tracker.getBitrate = () => 5000000;
+      tracker.getRenditionBitrate = () => 4000000;
+
+      // Before content starts (only request sent)
+      tracker.sendRequest();
+      let attrsBeforeStart = tracker.getAttributes();
+      expect(attrsBeforeStart.contentBitrate).to.be.undefined;
+      expect(attrsBeforeStart.contentRenditionBitrate).to.be.undefined;
+
+      // After content starts
+      tracker.sendStart();
+      let attrsAfterStart = tracker.getAttributes();
+      expect(attrsAfterStart.contentBitrate).to.equal(5000000);
+      expect(attrsAfterStart.contentRenditionBitrate).to.equal(4000000);
+
+      // Other rendition attributes should still be included (even if null) before start
+      expect(attrsBeforeStart).to.have.property("contentRenditionName");
+      expect(attrsBeforeStart).to.have.property("contentRenditionHeight");
+      expect(attrsBeforeStart).to.have.property("contentRenditionWidth");
+
+      // Cleanup
+      delete global.window;
+      delete global.document;
+    });
+
+    it("should drop bitrate attributes before ad start", () => {
+      // Setup jsdom environment
+      const dom = new JSDOM("<!doctype html><html><body></body></html>");
+      global.window = dom.window;
+      global.document = dom.window.document;
+
+      tracker = new VideoTracker();
+      tracker.setIsAd(true);
+
+      // Mock getBitrate to return a value
+      tracker.getBitrate = () => 3000000;
+      tracker.getRenditionBitrate = () => 2500000;
+
+      // Before ad starts (only request sent)
+      tracker.sendRequest();
+      let attrsBeforeStart = tracker.getAttributes();
+      expect(attrsBeforeStart.adBitrate).to.be.undefined;
+      expect(attrsBeforeStart.adRenditionBitrate).to.be.undefined;
+
+      // After ad starts
+      tracker.sendStart();
+      let attrsAfterStart = tracker.getAttributes();
+      expect(attrsAfterStart.adBitrate).to.equal(3000000);
+      expect(attrsAfterStart.adRenditionBitrate).to.equal(2500000);
+
+      // Other rendition attributes should still be included (even if null) before start
+      expect(attrsBeforeStart).to.have.property("adRenditionName");
+      expect(attrsBeforeStart).to.have.property("adRenditionHeight");
+      expect(attrsBeforeStart).to.have.property("adRenditionWidth");
+
+      // Cleanup
+      delete global.window;
+      delete global.document;
+    });
   });
 
   function generateTests(ads) {


### PR DESCRIPTION
## Drop bitrate attributes before content/ad start
### Summary
Bitrate attributes (contentBitrate, contentRenditionBitrate, adBitrate, adRenditionBitrate) are now only included in events after content or ad has started playing.

### Changes
Modified `getAttributes()` in [videotracker.js] to check this.state.isStarted before adding bitrate attributes

### Impact
CONTENT_REQUEST and AD_REQUEST events no longer include bitrate attributes
CONTENT_START, AD_START, and subsequent events continue to include bitrate attributes
Ensures bitrate is only reported after the first frame is shown, when actual bitrate data is meaningful