### PR TITLE
NR-528341: Rename QOE playback failure attrs to error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [4.1.1] - 2026/03/13
+
+### Fix
+
+- **Rename QOE playback failure attrs to error**
+  Renamed `hadStartupFailure` and `hadPlaybackFailure` properties to `hadStartupError` and `hadPlaybackError` in `videotrackerstate.js` to align with error terminology.
+
 ## [4.1.0] - 2026/02/18
 
 ### Feat

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/video-core",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "New Relic video tracking core library",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/src/videotrackerstate.js
+++ b/src/videotrackerstate.js
@@ -104,14 +104,14 @@ class VideoTrackerState {
     this.partialAverageBitrate = 0;
 
     /**
-     * Had Startup Failure: TRUE if CONTENT_ERROR occurs before CONTENT_START.
+     * Had Startup Error: TRUE if CONTENT_ERROR occurs before CONTENT_START.
      */
-    this.hadStartupFailure = false;
+    this.hadStartupError = false;
 
     /**
-     * Had Playback Failure: TRUE if CONTENT_ERROR occurs during content playback.
+     * Had Playback Error: TRUE if CONTENT_ERROR occurs during content playback.
      */
-    this.hadPlaybackFailure = false;
+    this.hadPlaybackError = false;
 
     /**
      * The amount of ms the user has been rebuffering during content playback.
@@ -354,8 +354,8 @@ class VideoTrackerState {
           if (this.peakBitrate > 0) {
               kpi["peakBitrate"] = this.peakBitrate;
           }
-          kpi["hadStartupFailure"] = this.hadStartupFailure;
-          kpi["hadPlaybackFailure"] = this.hadPlaybackFailure;
+          kpi["hadStartupError"] = this.hadStartupError;
+          kpi["hadPlaybackError"] = this.hadPlaybackError;
           kpi["totalRebufferingTime"] = this.totalRebufferingTime;
           // Calculate rebuffering ratio as percentage (avoid division by zero)
           kpi["rebufferingRatio"] = this.totalPlaytime > 0
@@ -670,13 +670,13 @@ class VideoTrackerState {
     } else {
       this.timeSinceLastError.start();
 
-      // Track failure flags for content errors only
-      // Had Startup Failure: error before content started
+      // Track error flags for content errors only
+      // Had Startup Error: error before content started
       if (!this.isStarted) {
-        this.hadStartupFailure = true;
+        this.hadStartupError = true;
       } else {
-        // Had Playback Failure: any content error
-        this.hadPlaybackFailure = true;
+        // Had Playback Error: any content error
+        this.hadPlaybackError = true;
       }
     }
   }

--- a/test/qoe-aggregate.spec.js
+++ b/test/qoe-aggregate.spec.js
@@ -33,8 +33,8 @@ describe("QOE_AGGREGATE Buffer Management", () => {
       actionName: Tracker.Events.QOE_AGGREGATE,
       qoeAggregateVersion: "1.0.0",
       "kpi.totalPlaytime": 1000,
-      "kpi.hadStartupFailure": false,
-      "kpi.hadPlaybackFailure": false
+      "kpi.hadStartupError": false,
+      "kpi.hadPlaybackError": false
     };
 
     const result = videoAnalyticsHarvester.addEvent(qoeEvent);
@@ -94,8 +94,8 @@ describe("QOE_AGGREGATE Buffer Management", () => {
       "kpi.averageBitrate": 1800,
       "kpi.totalRebufferingTime": 500,
       "kpi.rebufferingRatio": 5.5,
-      "kpi.hadStartupFailure": false,
-      "kpi.hadPlaybackFailure": true,
+      "kpi.hadStartupError": false,
+      "kpi.hadPlaybackError": true,
       "kpi.startupTime": 300
     };
 

--- a/test/videotrackerstate.spec.js
+++ b/test/videotrackerstate.spec.js
@@ -290,8 +290,8 @@ describe("VideoTrackerState", () => {
       expect(state.startupTime).toBeNull();
       expect(state.peakBitrate).toBe(0);
       expect(state.partialAverageBitrate).toBe(0);
-      expect(state.hadStartupFailure).toBe(false);
-      expect(state.hadPlaybackFailure).toBe(false);
+      expect(state.hadStartupError).toBe(false);
+      expect(state.hadPlaybackError).toBe(false);
       expect(state.totalRebufferingTime).toBe(0);
     });
 
@@ -330,14 +330,14 @@ describe("VideoTrackerState", () => {
       expect(state.peakBitrate).toBe(2000);
     });
 
-    it("should not set hadStartupFailure if error occurs after start", () => {
+    it("should not set hadStartupError if error occurs after start", () => {
       state.goRequest();
       state.goStart();
       expect(state.isStarted).toBe(true);
 
       state.goError();
-      expect(state.hadStartupFailure).toBe(false);
-      expect(state.hadPlaybackFailure).toBe(true);
+      expect(state.hadStartupError).toBe(false);
+      expect(state.hadPlaybackError).toBe(true);
     });
 
     it("getQoeAttributes() should return all KPI attributes with correct structure", () => {
@@ -348,8 +348,8 @@ describe("VideoTrackerState", () => {
       state.peakBitrate = 2000;
       state.partialAverageBitrate = 6000;
       state.weightedBitrate = 1200; // Set the weighted bitrate that will be used in averageBitrate
-      state.hadStartupFailure = false;
-      state.hadPlaybackFailure = true;
+      state.hadStartupError = false;
+      state.hadPlaybackError = true;
       state.totalRebufferingTime = 300;
       state.totalPlaytime = 5000;
       state.numberOfErrors = 3;
@@ -361,8 +361,8 @@ describe("VideoTrackerState", () => {
       expect(typeof result.qoe).toBe("object");
       expect(qoeAttrs["startupTime"]).toBe(500);
       expect(qoeAttrs["peakBitrate"]).toBe(2000);
-      expect(qoeAttrs["hadStartupFailure"]).toBe(false);
-      expect(qoeAttrs["hadPlaybackFailure"]).toBe(true);
+      expect(qoeAttrs["hadStartupError"]).toBe(false);
+      expect(qoeAttrs["hadPlaybackError"]).toBe(true);
       expect(qoeAttrs["totalRebufferingTime"]).toBe(300);
       expect(qoeAttrs["rebufferingRatio"]).toBeCloseTo(6, 0);
       expect(qoeAttrs["totalPlaytime"]).toBe(5000);


### PR DESCRIPTION
- Rename hadPlaybackFailure → hadPlaybackError in videotrackerstate.js
- Rename hadStartupFailure → hadStartupError in videotrackerstate.js
- Update corresponding test files