### PR TITLE
fix: QoE aggregate improvements - KPI accuracy, harvest lifecycle, dedup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [4.1.2] - 2026/03/18
+
+### Fix
+
+- **QoE aggregate improvements - KPI accuracy**
+  Fixed startup time, average bitrate, and rebuffering time calculations for more accurate QoE KPI reporting
+
+- **QoE harvest lifecycle and dedup**
+  Improved harvest cycle management with state refresh before drain, forced QoE at `CONTENT_END`, cross-cycle dirty check to skip unchanged KPIs.
+
 ## [4.1.0] - 2026/02/18
 
 ### Feat

--- a/DATAMODEL.md
+++ b/DATAMODEL.md
@@ -79,8 +79,8 @@ An Attribute is a piece of data associated with an event. Attributes provide add
 | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
 | startupTime      | Time from CONTENT_REQUEST to CONTENT_START in milliseconds. Measures video startup performance. Only included if value is not null.                |
 | peakBitrate      | Maximum contentBitrate (in bits per second) observed during content playback. Tracks the highest quality achieved. Only included if value > 0.     |
-| hadStartupFailure | Boolean indicating if CONTENT_ERROR occurred before CONTENT_START. True if video failed to start due to an error.                                 |
-| hadPlaybackFailure | Boolean indicating if CONTENT_ERROR occurred at any time during content playback.                                                                |
+| hadStartupError | Boolean indicating if CONTENT_ERROR occurred before CONTENT_START. True if video failed to start due to an error.                                 |
+| hadPlaybackError | Boolean indicating if CONTENT_ERROR occurred at any time during content playback.                                                                |
 | totalRebufferingTime | Total milliseconds spent rebuffering during content playback (excludes initial buffering).                                                      |
 | rebufferingRatio | Rebuffering time as a percentage of total playtime. Calculated as (totalRebufferingTime / totalPlaytime) × 100.                                    |
 | totalPlaytime    | Total milliseconds user spent watching content (excludes pausing, buffering, and ads). Represents actual content viewing time.                     |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/video-core",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "New Relic video tracking core library",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/src/agent.js
+++ b/src/agent.js
@@ -1,5 +1,6 @@
 import { HarvestScheduler } from "./harvestScheduler.js";
 import { NrVideoEventAggregator } from "./eventAggregator.js";
+import Constants from "./constants.js";
 import Log from "./log.js";
 import Tracker from "./tracker";
 
@@ -49,7 +50,8 @@ class VideoAnalyticsAgent {
 
     try {
       if(eventObject.actionName && eventObject.actionName === Tracker.Events.QOE_AGGREGATE) {
-          // This makes sure that there is only one QOE aggregate event for a harvest cycle
+          // Ensure only one QOE_AGGREGATE event exists in buffer per harvest cycle.
+          // Dirty-check dedup happens at drain time in HarvestScheduler._qoeKpisUnchanged().
           return this.eventBuffer.addOrReplaceByActionName(Tracker.Events.QOE_AGGREGATE, eventObject);
       }
       return this.eventBuffer.add(eventObject);
@@ -70,6 +72,45 @@ class VideoAnalyticsAgent {
     }
 
     this.harvestScheduler.updateHarvestInterval(interval);
+  }
+
+  /**
+   * Forces the next harvest cycle to include QOE_AGGREGATE events.
+   * Called at CONTENT_END to ensure final QoE is sent.
+   */
+  forceNextQoeCycle() {
+    if (this.harvestScheduler) {
+      this.harvestScheduler.forceNextQoeCycle = true;
+    }
+  }
+
+  /**
+   * Sets a callback to be called before each drain to refresh QoE KPIs.
+   * @param {Function|null} callback - Function that refreshes QoE data in the buffer, or null to clear
+   */
+  setBeforeDrainCallback(callback) {
+    if (this.harvestScheduler) {
+      this.harvestScheduler.beforeDrainCallback = callback;
+    }
+  }
+
+  /**
+   * Updates QoE KPI fields on the existing QOE_AGGREGATE event in the buffer.
+   * Uses addOrReplaceByActionName to keep payload size tracking accurate.
+   * @param {object} freshKpis - Object with latest KPI values
+   */
+  refreshQoeKpis(freshKpis) {
+    if (!this.eventBuffer || !freshKpis) return;
+    const existing = this.eventBuffer.findByActionName(Tracker.Events.QOE_AGGREGATE);
+    if (existing) {
+      const updated = { ...existing };
+      for (const key of Constants.QOE_KPI_KEYS) {
+        if (key in freshKpis) {
+          updated[key] = freshKpis[key];
+        }
+      }
+      this.eventBuffer.addOrReplaceByActionName(Tracker.Events.QOE_AGGREGATE, updated);
+    }
   }
 }
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -42,6 +42,12 @@ Constants.MAX_BEACON_SIZE = 61440; // 60KB = 60 × 1024 bytes
 Constants.MAX_EVENTS_PER_BATCH = 1000;
 Constants.INTERVAL = 10000; //10 seconds
 
+Constants.QOE_KPI_KEYS = [
+    "startupTime", "peakBitrate", "averageBitrate", "totalPlaytime",
+    "totalRebufferingTime", "rebufferingRatio", "hadStartupError",
+    "hadPlaybackError", "numberOfErrors"
+];
+
 Constants.QOE_AGGREGATE_KEYS = [
     "coreVersion", "instrumentation.name",
     "instrumentation.provider", "instrumentation.version", "isBackgroundEvent", "playerName", "playerVersion",

--- a/src/eventAggregator.js
+++ b/src/eventAggregator.js
@@ -56,6 +56,16 @@ export class NrVideoEventAggregator {
     }
 
   /**
+   * Returns the existing event in buffer matching the given actionName, or null.
+   * @param {string} actionName
+   * @returns {object|null}
+   */
+  findByActionName(actionName) {
+      const event = this.buffer.find(e => e.actionName === actionName);
+      return event || null;
+  }
+
+  /**
    * Adds an event to the unified buffer.
    * All events are treated equally in FIFO order.
    * @param {object} eventObject - The event to add

--- a/src/harvestScheduler.js
+++ b/src/harvestScheduler.js
@@ -3,6 +3,7 @@ import { RetryQueueHandler } from "./retryQueueHandler";
 import { OptimizedHttpClient } from "./optimizedHttpClient";
 import { buildUrl, dataSize } from "./utils";
 import Constants from "./constants";
+import Tracker from "./tracker";
 import Log from "./log";
 
 /**
@@ -32,6 +33,9 @@ export class HarvestScheduler {
     this.harvestCycle = Constants.INTERVAL;
     this.isHarvesting = false;
     this.qoeCycleCount = 1;
+    this.forceNextQoeCycle = false;
+    this.beforeDrainCallback = null;
+    this._lastSentQoeKpis = null;
 
     // Page lifecycle handling
     this.setupPageLifecycleHandlers();
@@ -247,17 +251,53 @@ export class HarvestScheduler {
   drainEvents(options = {}) {
     // Determine if this cycle should include the QOE_AGGREGATE event
     const multiplier = window.NRVIDEO?.config?.qoeIntervalFactor ?? 1;
+    const isForced = !!options.isFinalHarvest || this.forceNextQoeCycle;
     const isQoeCycle =
-      (this.qoeCycleCount - 1) % multiplier === 0 ||
-      !!options.isFinalHarvest;
+      (this.qoeCycleCount - 1) % multiplier === 0 || isForced;
+
+    // Reset force flag after use
+    if (this.forceNextQoeCycle) this.forceNextQoeCycle = false;
+
+    // Refresh QoE KPIs with latest tracker state before draining
+    if (this.beforeDrainCallback && typeof this.beforeDrainCallback === 'function') {
+      try {
+        this.beforeDrainCallback();
+      } catch (e) {
+        Log.error("Before drain callback failed:", e.message);
+      }
+    }
 
     // Always drain fresh events first (priority approach)
     const freshEvents = this.eventBuffer.drain();
-    const filteredFreshEvents = isQoeCycle
-      ? freshEvents
-      : freshEvents.filter((e) => e.actionName !== "QOE_AGGREGATE");
+    let filteredFreshEvents;
+    if (isQoeCycle) {
+      filteredFreshEvents = freshEvents;
+    } else {
+      // On non-QoE cycles, put QoE events back into buffer instead of losing them
+      filteredFreshEvents = [];
+      for (const e of freshEvents) {
+        if (e.actionName === Tracker.Events.QOE_AGGREGATE) {
+          this.eventBuffer.add(e);
+        } else {
+          filteredFreshEvents.push(e);
+        }
+      }
+    }
 
     this.qoeCycleCount++;
+
+    // Cross-cycle dirty check: skip QoE if KPIs unchanged since last send
+    // Forced cycles (CONTENT_END, page unload) always send QoE
+    for (let i = filteredFreshEvents.length - 1; i >= 0; i--) {
+      const e = filteredFreshEvents[i];
+      if (e.actionName === Tracker.Events.QOE_AGGREGATE) {
+        if (!isForced && this._qoeKpisUnchanged(e)) {
+          filteredFreshEvents.splice(i, 1);
+        } else {
+          this._saveQoeKpis(e);
+        }
+      }
+    }
 
     let events = [...filteredFreshEvents];
     let currentPayloadSize = dataSize(filteredFreshEvents);
@@ -427,5 +467,31 @@ export class HarvestScheduler {
     window.addEventListener("beforeunload", () => {
       triggerFinalHarvest();
     });
+  }
+
+  /**
+   * Checks if QoE KPIs are unchanged since last send.
+   * @param {object} event - QoE event to compare
+   * @returns {boolean} True if KPIs are identical to last sent
+   * @private
+   */
+  _qoeKpisUnchanged(event) {
+    if (!this._lastSentQoeKpis) return false;
+    for (const key of Constants.QOE_KPI_KEYS) {
+      if (event[key] !== this._lastSentQoeKpis[key]) return false;
+    }
+    return true;
+  }
+
+  /**
+   * Saves QoE KPI values after sending.
+   * @param {object} event - QoE event that was sent
+   * @private
+   */
+  _saveQoeKpis(event) {
+    this._lastSentQoeKpis = {};
+    for (const key of Constants.QOE_KPI_KEYS) {
+      this._lastSentQoeKpis[key] = event[key];
+    }
   }
 }

--- a/src/videotracker.js
+++ b/src/videotracker.js
@@ -567,8 +567,10 @@ class VideoTracker extends Tracker {
 
   addQoeAttributes(att) {
       att = this.state.getQoeAttributes(att);
-      // QOE events should only contain KPIs from state and whitelisted metadata
-      // from QOE_AGGREGATE_KEYS — custom attributes are intentionally excluded.
+      const qoe = att.qoe;
+      for (let key in this.customData) {
+          qoe[key] = this.customData[key];
+      }
   }
 
   /**

--- a/src/videotracker.js
+++ b/src/videotracker.js
@@ -1,6 +1,7 @@
 import Log from "./log";
 import Tracker from "./tracker";
 import TrackerState from "./videotrackerstate";
+import { videoAnalyticsHarvester } from "./agent";
 import pkg from "../package.json";
 
 /**
@@ -566,10 +567,8 @@ class VideoTracker extends Tracker {
 
   addQoeAttributes(att) {
       att = this.state.getQoeAttributes(att);
-      const qoe = att.qoe;
-      for (let key in this.customData) {
-          qoe[key] = this.customData[key];
-      }
+      // QOE events should only contain KPIs from state and whitelisted metadata
+      // from QOE_AGGREGATE_KEYS — custom attributes are intentionally excluded.
   }
 
   /**
@@ -637,15 +636,23 @@ class VideoTracker extends Tracker {
         if(this.adsTracker) {
           // If ads state is set to playing (ad error) after content start, reset the ad state.
           if(this.adsTracker.state.isPlaying || this.adsTracker.state.isBuffering) {
-            totalAdsTime = this.adsTracker.state.stopAdsTime();
+            this.adsTracker.state.stopAdsTime();
             this.adsTracker.state.isPlaying = false;
             this.adsTracker.state.isBuffering = false;
-          } else {
-            totalAdsTime = this.adsTracker.state.totalAdTime() ?? 0;
           }
+          // Always use totalAdTime() which includes accumulator across all ads
+          totalAdsTime = this.adsTracker.state.totalAdTime() ?? 0;
         }
         this.state.setStartupTime(totalAdsTime)
         this.sendVideoAction(ev, att);
+
+        // Register callback to refresh QoE KPIs with latest state before each drain
+        videoAnalyticsHarvester.setBeforeDrainCallback(() => {
+          if (this.state) {
+            const freshKpis = this.state.getQoeAttributes({}).qoe;
+            videoAnalyticsHarvester.refreshQoeKpis(freshKpis);
+          }
+        });
       }
       //this.send(ev, att);
       this.startHeartbeat();
@@ -685,6 +692,11 @@ class VideoTracker extends Tracker {
       this.state.goViewCountUp();
       this.state.totalPlaytime = 0;
       if(!this.isAd()) {
+        // Force QoE to be included in the next harvest cycle at content end
+          videoAnalyticsHarvester.forceNextQoeCycle();
+        // Clear the before-drain callback so the next harvest doesn't overwrite
+        // the final QoE (already in buffer) with zeroed-out state values
+          videoAnalyticsHarvester.setBeforeDrainCallback(null);
         // reset the states after the view count is up
           if(this.adsTracker) this.adsTracker.state.clearTotalAdsTime();
           this.state.resetViewIdTrackedState();

--- a/src/videotrackerstate.js
+++ b/src/videotrackerstate.js
@@ -104,14 +104,19 @@ class VideoTrackerState {
     this.partialAverageBitrate = 0;
 
     /**
-     * Had Startup Failure: TRUE if CONTENT_ERROR occurs before CONTENT_START.
+     * Total duration (ms) of all closed bitrate segments for weighted average
      */
-    this.hadStartupFailure = false;
+    this._totalBitrateDuration = 0;
 
     /**
-     * Had Playback Failure: TRUE if CONTENT_ERROR occurs during content playback.
+     * Had Startup Error: TRUE if CONTENT_ERROR occurs before CONTENT_START.
      */
-    this.hadPlaybackFailure = false;
+    this.hadStartupError = false;
+
+    /**
+     * Had Playback Error: TRUE if CONTENT_ERROR occurs during content playback.
+     */
+    this.hadPlaybackError = false;
 
     /**
      * The amount of ms the user has been rebuffering during content playback.
@@ -354,8 +359,8 @@ class VideoTrackerState {
           if (this.peakBitrate > 0) {
               kpi["peakBitrate"] = this.peakBitrate;
           }
-          kpi["hadStartupFailure"] = this.hadStartupFailure;
-          kpi["hadPlaybackFailure"] = this.hadPlaybackFailure;
+          kpi["hadStartupError"] = this.hadStartupError;
+          kpi["hadPlaybackError"] = this.hadPlaybackError;
           kpi["totalRebufferingTime"] = this.totalRebufferingTime;
           // Calculate rebuffering ratio as percentage (avoid division by zero)
           kpi["rebufferingRatio"] = this.totalPlaytime > 0
@@ -549,8 +554,10 @@ class VideoTrackerState {
       }
 
       // Accumulate total rebuffering time for content only
+      // Use exact stopped duration (stopTime - startTime) instead of live getDeltaTime()
       if (!this.isAd() && this.initialBufferingHappened) {
-        this.totalRebufferingTime += this.timeSinceBufferBegin.getDeltaTime();
+        this.totalRebufferingTime +=
+            (this.timeSinceBufferBegin.stopTime - this.timeSinceBufferBegin.startTime);
       }
 
       return true;
@@ -670,13 +677,13 @@ class VideoTrackerState {
     } else {
       this.timeSinceLastError.start();
 
-      // Track failure flags for content errors only
-      // Had Startup Failure: error before content started
+      // Track error flags for content errors only
+      // Had Startup Error: error before content started
       if (!this.isStarted) {
-        this.hadStartupFailure = true;
+        this.hadStartupError = true;
       } else {
-        // Had Playback Failure: any content error
-        this.hadPlaybackFailure = true;
+        // Had Playback Error: any content error during playback
+        this.hadPlaybackError = true;
       }
     }
   }
@@ -696,14 +703,57 @@ class VideoTrackerState {
     if (bitrate && typeof bitrate === "number") {
       this.peakBitrate = Math.max(this.peakBitrate, bitrate);
 
-      if(this._lastBitrate === null || this._lastBitrate !== bitrate) {
-        const deltaPlaytime = this._lastBitrateChangeTimestamp === null ? this.totalPlaytime : Date.now() - this._lastBitrateChangeTimestamp;
-        const currentWeightedBitrate = (bitrate * deltaPlaytime);
-        this.partialAverageBitrate += currentWeightedBitrate;
-        this.weightedBitrate = currentWeightedBitrate / deltaPlaytime;
+      const now = Date.now();
+
+      // If not playing (buffering, paused, etc.), close the current segment
+      // so non-play time is excluded from the weighted average
+      if (!this.isPlaying) {
+        if (this._lastBitrate !== null && this._lastBitrateChangeTimestamp !== null) {
+          const segmentDuration = now - this._lastBitrateChangeTimestamp;
+          if (segmentDuration > 0) {
+            this.partialAverageBitrate += this._lastBitrate * segmentDuration;
+            this._totalBitrateDuration += segmentDuration;
+          }
+          this._lastBitrateChangeTimestamp = null; // Mark as paused
+        }
         this._lastBitrate = bitrate;
-        this._lastBitrateChangeTimestamp = Date.now();
+        return;
       }
+
+      // Playing: restart timestamp if returning from non-play state
+      if (this._lastBitrateChangeTimestamp === null && this._lastBitrate !== null) {
+        this._lastBitrateChangeTimestamp = now;
+      }
+
+      // Close the PREVIOUS segment when bitrate changes
+      if (this._lastBitrate !== null && this._lastBitrate !== bitrate
+          && this._lastBitrateChangeTimestamp !== null) {
+        const segmentDuration = now - this._lastBitrateChangeTimestamp;
+        if (segmentDuration > 0) {
+          this.partialAverageBitrate += this._lastBitrate * segmentDuration;
+          this._totalBitrateDuration += segmentDuration;
+        }
+        this._lastBitrateChangeTimestamp = now;
+      }
+
+      // Initialize timestamp on first observation
+      if (this._lastBitrateChangeTimestamp === null) {
+        this._lastBitrateChangeTimestamp = now;
+      }
+
+      this._lastBitrate = bitrate;
+
+      // Compute weighted average including current in-progress segment
+      let totalWeighted = this.partialAverageBitrate;
+      let totalDuration = this._totalBitrateDuration;
+      const currentSegment = now - this._lastBitrateChangeTimestamp;
+      if (currentSegment > 0) {
+        totalWeighted += bitrate * currentSegment;
+        totalDuration += currentSegment;
+      }
+      this.weightedBitrate = totalDuration > 0
+          ? Math.round(totalWeighted / totalDuration)
+          : bitrate;
     }
   }
 
@@ -713,6 +763,7 @@ class VideoTrackerState {
   resetViewIdTrackedState() {
     this.peakBitrate = 0;
     this.partialAverageBitrate = 0;
+    this._totalBitrateDuration = 0;
     this.startupTime = null;
     this._lastBitrate = null;
     this._lastBitrateChangeTimestamp = null;
@@ -720,7 +771,7 @@ class VideoTrackerState {
 
   /** Methods to manage total ads time chrono */
   clearTotalAdsTime() {
-    console.log("clear total ads time", this.totalAdTime);
+    Log.debug("clear total ads time", this.totalAdTime);
     this._totalAdPlaytime.reset();
   }
 
@@ -729,12 +780,12 @@ class VideoTrackerState {
   }
 
   startAdsTime() {
-    console.log("startAdsTime");
+    Log.debug("startAdsTime");
     return this._totalAdPlaytime.start();
   }
 
   stopAdsTime() {
-    console.log("stopAdsTime");
+    Log.debug("stopAdsTime");
     return this._totalAdPlaytime.stop();
   }
 

--- a/test/agent.spec.js
+++ b/test/agent.spec.js
@@ -111,4 +111,90 @@ describe('videoAnalyticsHarvester', function() {
       expect(videoAnalyticsHarvester.harvestScheduler.harvestCycle).toBe(20000);
     });
   });
+
+  describe('forceNextQoeCycle()', function() {
+    it('should set forceNextQoeCycle flag on harvest scheduler', function() {
+      expect(videoAnalyticsHarvester.harvestScheduler.forceNextQoeCycle).toBe(false);
+
+      videoAnalyticsHarvester.forceNextQoeCycle();
+
+      expect(videoAnalyticsHarvester.harvestScheduler.forceNextQoeCycle).toBe(true);
+    });
+  });
+
+  describe('QOE_AGGREGATE buffer management', function() {
+    beforeEach(function() {
+      if (videoAnalyticsHarvester.eventBuffer) {
+        videoAnalyticsHarvester.eventBuffer.clear();
+      }
+    });
+
+    it('should always replace QOE_AGGREGATE in buffer (dedup happens at drain time)', function() {
+      const qoe1 = {actionName: 'QOE_AGGREGATE', totalPlaytime: 1000, peakBitrate: 2000};
+      const qoe2 = {actionName: 'QOE_AGGREGATE', totalPlaytime: 1000, peakBitrate: 2000, timestamp: 9999};
+
+      videoAnalyticsHarvester.addEvent(qoe1);
+      videoAnalyticsHarvester.addEvent(qoe2);
+
+      const events = videoAnalyticsHarvester.eventBuffer.drain();
+      expect(events.length).toBe(1);
+      // Should have the latest event (replaced)
+      expect(events[0].timestamp).toBe(9999);
+    });
+
+    it('should replace QOE_AGGREGATE when KPIs differ', function() {
+      const qoe1 = {actionName: 'QOE_AGGREGATE', totalPlaytime: 1000};
+      const qoe2 = {actionName: 'QOE_AGGREGATE', totalPlaytime: 5000};
+
+      videoAnalyticsHarvester.addEvent(qoe1);
+      videoAnalyticsHarvester.addEvent(qoe2);
+
+      const events = videoAnalyticsHarvester.eventBuffer.drain();
+      expect(events.length).toBe(1);
+      expect(events[0].totalPlaytime).toBe(5000);
+    });
+  });
+
+  describe('setBeforeDrainCallback()', function() {
+    it('should set beforeDrainCallback on harvest scheduler', function() {
+      const callback = function() {};
+      videoAnalyticsHarvester.setBeforeDrainCallback(callback);
+
+      expect(videoAnalyticsHarvester.harvestScheduler.beforeDrainCallback).toBe(callback);
+    });
+  });
+
+  describe('refreshQoeKpis()', function() {
+    beforeEach(function() {
+      if (videoAnalyticsHarvester.eventBuffer) {
+        videoAnalyticsHarvester.eventBuffer.clear();
+      }
+    });
+
+    it('should update KPI fields on existing QOE_AGGREGATE in buffer', function() {
+      const qoe = {actionName: 'QOE_AGGREGATE', totalPlaytime: 1000, peakBitrate: 2000};
+      videoAnalyticsHarvester.addEvent(qoe);
+
+      // Refresh with updated KPIs
+      videoAnalyticsHarvester.refreshQoeKpis({totalPlaytime: 5000, peakBitrate: 3000});
+
+      const events = videoAnalyticsHarvester.eventBuffer.drain();
+      expect(events.length).toBe(1);
+      expect(events[0].totalPlaytime).toBe(5000);
+      expect(events[0].peakBitrate).toBe(3000);
+      // actionName should be preserved
+      expect(events[0].actionName).toBe('QOE_AGGREGATE');
+    });
+
+    it('should do nothing if no QOE_AGGREGATE exists in buffer', function() {
+      videoAnalyticsHarvester.addEvent({actionName: 'PLAY'});
+
+      // Should not throw
+      videoAnalyticsHarvester.refreshQoeKpis({totalPlaytime: 5000});
+
+      const events = videoAnalyticsHarvester.eventBuffer.drain();
+      expect(events.length).toBe(1);
+      expect(events[0].actionName).toBe('PLAY');
+    });
+  });
 });

--- a/test/harvestScheduler.spec.js
+++ b/test/harvestScheduler.spec.js
@@ -287,6 +287,178 @@ describe('HarvestScheduler', function() {
     });
   });
 
+  describe('drainEvents() - QoE cycle handling', function() {
+    beforeEach(function() {
+      scheduler = new HarvestScheduler(mockEventBuffer);
+      scheduler.retryQueueHandler.getQueueSize = sinon.stub().returns(0);
+    });
+
+    it('should re-buffer QoE events on non-QoE cycles instead of losing them', function() {
+      global.window.NRVIDEO.config = { qoeIntervalFactor: 3 };
+
+      const qoeEvent = { actionName: 'QOE_AGGREGATE', totalPlaytime: 1000 };
+      const playEvent = { actionName: 'PLAY' };
+      mockEventBuffer.drain.returns([playEvent, qoeEvent]);
+      mockEventBuffer.add = sinon.stub();
+
+      // Cycle 1 is QoE cycle (1-1) % 3 === 0
+      let events = scheduler.drainEvents();
+      expect(events.some(e => e.actionName === 'QOE_AGGREGATE')).toBe(true);
+      expect(mockEventBuffer.add.called).toBe(false);
+
+      // Cycle 2 is NOT QoE cycle (2-1) % 3 !== 0
+      mockEventBuffer.drain.returns([playEvent, qoeEvent]);
+      events = scheduler.drainEvents();
+      expect(events.some(e => e.actionName === 'QOE_AGGREGATE')).toBe(false);
+      // QoE should be put back into buffer
+      expect(mockEventBuffer.add.calledWith(qoeEvent)).toBe(true);
+    });
+
+    it('should preserve QoE timestamp from capture time (not override at drain)', function() {
+      const qoeEvent = { actionName: 'QOE_AGGREGATE', timestamp: 1000 };
+      mockEventBuffer.drain.returns([qoeEvent]);
+
+      clock.tick(5000);
+      scheduler.drainEvents();
+
+      expect(qoeEvent.timestamp).toBe(1000); // Timestamp stays from capture time
+    });
+
+    it('should include QoE when forceNextQoeCycle is set', function() {
+      global.window.NRVIDEO.config = { qoeIntervalFactor: 100 };
+
+      const qoeEvent = { actionName: 'QOE_AGGREGATE', totalPlaytime: 1000 };
+      mockEventBuffer.drain.returns([{ actionName: 'PLAY' }, qoeEvent]);
+      mockEventBuffer.add = sinon.stub();
+
+      // Force QoE inclusion on non-QoE cycle
+      scheduler.qoeCycleCount = 2; // Not a QoE cycle
+      scheduler.forceNextQoeCycle = true;
+
+      const events = scheduler.drainEvents();
+      expect(events.some(e => e.actionName === 'QOE_AGGREGATE')).toBe(true);
+      expect(scheduler.forceNextQoeCycle).toBe(false); // Flag reset
+    });
+
+    it('should initialize forceNextQoeCycle to false', function() {
+      expect(scheduler.forceNextQoeCycle).toBe(false);
+    });
+
+    it('should call beforeDrainCallback before draining events', function() {
+      const callback = sinon.stub();
+      scheduler.beforeDrainCallback = callback;
+
+      mockEventBuffer.drain.returns([{ actionName: 'PLAY' }]);
+      scheduler.drainEvents();
+
+      expect(callback.calledOnce).toBe(true);
+      // Callback should be called before drain
+      expect(callback.calledBefore(mockEventBuffer.drain)).toBe(true);
+    });
+
+    it('should refresh QoE KPIs via beforeDrainCallback before sending', function() {
+      const qoeEvent = { actionName: 'QOE_AGGREGATE', totalPlaytime: 1000, peakBitrate: 2000 };
+
+      // Simulate a callback that updates the QoE event's KPIs (as refreshQoeKpis would)
+      scheduler.beforeDrainCallback = function() {
+        // Find QoE in buffer and update it (mimics agent.refreshQoeKpis)
+        const existing = scheduler.eventBuffer.findByActionName('QOE_AGGREGATE');
+        if (existing) {
+          existing.totalPlaytime = 5000;
+          existing.peakBitrate = 4000;
+        }
+      };
+
+      // Use real buffer for this test
+      const { NrVideoEventAggregator } = require('../src/eventAggregator');
+      const realBuffer = new NrVideoEventAggregator();
+      realBuffer.add(qoeEvent);
+      scheduler.eventBuffer = realBuffer;
+
+      const events = scheduler.drainEvents();
+      const sentQoe = events.find(e => e.actionName === 'QOE_AGGREGATE');
+
+      expect(sentQoe).toBeDefined();
+      // KPIs should reflect the refreshed values, not the stale ones
+      expect(sentQoe.totalPlaytime).toBe(5000);
+      expect(sentQoe.peakBitrate).toBe(4000);
+    });
+
+    it('should initialize beforeDrainCallback to null', function() {
+      expect(scheduler.beforeDrainCallback).toBe(null);
+    });
+
+    it('should handle beforeDrainCallback errors gracefully', function() {
+      scheduler.beforeDrainCallback = sinon.stub().throws(new Error('callback error'));
+      mockEventBuffer.drain.returns([{ actionName: 'PLAY' }]);
+
+      // Should not throw, drain should still work
+      const events = scheduler.drainEvents();
+      expect(events.length).toBe(1);
+    });
+
+    it('should not send QoE if KPIs unchanged since last send (cross-cycle dirty check)', function() {
+      const qoe = { actionName: 'QOE_AGGREGATE', totalPlaytime: 1000, peakBitrate: 2000 };
+
+      // Cycle 1: QoE sent (first time, _lastSentQoeKpis is null)
+      mockEventBuffer.drain.returns([{ actionName: 'PLAY' }, { ...qoe }]);
+      let events = scheduler.drainEvents();
+      expect(events.some(e => e.actionName === 'QOE_AGGREGATE')).toBe(true);
+
+      // Cycle 2: Same KPIs — should NOT send QoE
+      mockEventBuffer.drain.returns([{ actionName: 'PLAY' }, { ...qoe }]);
+      events = scheduler.drainEvents();
+      expect(events.some(e => e.actionName === 'QOE_AGGREGATE')).toBe(false);
+      expect(events.some(e => e.actionName === 'PLAY')).toBe(true);
+    });
+
+    it('should send QoE when KPIs change from last send', function() {
+      const qoe1 = { actionName: 'QOE_AGGREGATE', totalPlaytime: 1000 };
+      const qoe2 = { actionName: 'QOE_AGGREGATE', totalPlaytime: 5000 };
+
+      // Cycle 1: Send first QoE
+      mockEventBuffer.drain.returns([{ ...qoe1 }]);
+      scheduler.drainEvents();
+
+      // Cycle 2: KPIs changed — should send
+      mockEventBuffer.drain.returns([{ ...qoe2 }]);
+      const events = scheduler.drainEvents();
+      expect(events.some(e => e.actionName === 'QOE_AGGREGATE')).toBe(true);
+      expect(events.find(e => e.actionName === 'QOE_AGGREGATE').totalPlaytime).toBe(5000);
+    });
+
+    it('should initialize _lastSentQoeKpis to null', function() {
+      expect(scheduler._lastSentQoeKpis).toBe(null);
+    });
+
+    it('should always send QoE when forceNextQoeCycle is set even if KPIs unchanged', function() {
+      const qoe = { actionName: 'QOE_AGGREGATE', totalPlaytime: 1000, peakBitrate: 2000 };
+
+      // Cycle 1: Send QoE (first time)
+      mockEventBuffer.drain.returns([{ ...qoe }]);
+      scheduler.drainEvents();
+
+      // Cycle 2: Same KPIs but forced — should still send
+      mockEventBuffer.drain.returns([{ ...qoe }]);
+      scheduler.forceNextQoeCycle = true;
+      const events = scheduler.drainEvents();
+      expect(events.some(e => e.actionName === 'QOE_AGGREGATE')).toBe(true);
+    });
+
+    it('should always send QoE on final harvest even if KPIs unchanged', function() {
+      const qoe = { actionName: 'QOE_AGGREGATE', totalPlaytime: 1000, peakBitrate: 2000 };
+
+      // Cycle 1: Send QoE (first time)
+      mockEventBuffer.drain.returns([{ ...qoe }]);
+      scheduler.drainEvents();
+
+      // Final harvest: Same KPIs but final — should still send
+      mockEventBuffer.drain.returns([{ ...qoe }]);
+      const events = scheduler.drainEvents({ isFinalHarvest: true });
+      expect(events.some(e => e.actionName === 'QOE_AGGREGATE')).toBe(true);
+    });
+  });
+
   describe('trimEventsToFit()', function() {
     beforeEach(function() {
       scheduler = new HarvestScheduler(mockEventBuffer);

--- a/test/qoe-aggregate.spec.js
+++ b/test/qoe-aggregate.spec.js
@@ -33,8 +33,8 @@ describe("QOE_AGGREGATE Buffer Management", () => {
       actionName: Tracker.Events.QOE_AGGREGATE,
       qoeAggregateVersion: "1.0.0",
       "kpi.totalPlaytime": 1000,
-      "kpi.hadStartupFailure": false,
-      "kpi.hadPlaybackFailure": false
+      "kpi.hadStartupError": false,
+      "kpi.hadPlaybackError": false
     };
 
     const result = videoAnalyticsHarvester.addEvent(qoeEvent);
@@ -51,22 +51,22 @@ describe("QOE_AGGREGATE Buffer Management", () => {
     const qoeEvent1 = {
       eventType: "VideoAction",
       actionName: Tracker.Events.QOE_AGGREGATE,
-      "kpi.totalPlaytime": 1000
+      totalPlaytime: 1000
     };
 
     const qoeEvent2 = {
       eventType: "VideoAction",
       actionName: Tracker.Events.QOE_AGGREGATE,
-      "kpi.totalPlaytime": 2000
+      totalPlaytime: 2000
     };
 
     const qoeEvent3 = {
       eventType: "VideoAction",
       actionName: Tracker.Events.QOE_AGGREGATE,
-      "kpi.totalPlaytime": 3000
+      totalPlaytime: 3000
     };
 
-    // Add multiple QOE events
+    // Add multiple QOE events (each has different KPIs so dirty check allows replace)
     videoAnalyticsHarvester.addEvent(qoeEvent1);
     videoAnalyticsHarvester.addEvent(qoeEvent2);
     videoAnalyticsHarvester.addEvent(qoeEvent3);
@@ -76,27 +76,27 @@ describe("QOE_AGGREGATE Buffer Management", () => {
 
     const events = videoAnalyticsHarvester.eventBuffer.drain();
     expect(events.length).toBe(1);
-    expect(events[0]["kpi.totalPlaytime"]).toBe(3000); // Latest value
+    expect(events[0].totalPlaytime).toBe(3000); // Latest value
   });
 
   it("should correctly adjust payload size when replacing QOE_AGGREGATE", () => {
     const smallQoeEvent = {
       eventType: "VideoAction",
       actionName: Tracker.Events.QOE_AGGREGATE,
-      "kpi.totalPlaytime": 1000
+      totalPlaytime: 1000
     };
 
     const largeQoeEvent = {
       eventType: "VideoAction",
       actionName: Tracker.Events.QOE_AGGREGATE,
-      "kpi.totalPlaytime": 2000,
-      "kpi.peakBitrate": 2000,
-      "kpi.averageBitrate": 1800,
-      "kpi.totalRebufferingTime": 500,
-      "kpi.rebufferingRatio": 5.5,
-      "kpi.hadStartupFailure": false,
-      "kpi.hadPlaybackFailure": true,
-      "kpi.startupTime": 300
+      totalPlaytime: 2000,
+      peakBitrate: 2000,
+      averageBitrate: 1800,
+      totalRebufferingTime: 500,
+      rebufferingRatio: 5.5,
+      hadStartupError: false,
+      hadPlaybackError: true,
+      startupTime: 300
     };
 
     // Add small event
@@ -148,19 +148,19 @@ describe("QOE_AGGREGATE Buffer Management", () => {
     const qoeEvent1 = {
       eventType: "VideoAction",
       actionName: Tracker.Events.QOE_AGGREGATE,
-      "kpi.totalPlaytime": 1000
+      totalPlaytime: 1000
     };
 
     const qoeEvent2 = {
       eventType: "VideoAction",
       actionName: Tracker.Events.QOE_AGGREGATE,
-      "kpi.totalPlaytime": 2000
+      totalPlaytime: 2000
     };
 
     const qoeEvent3 = {
       eventType: "VideoAction",
       actionName: Tracker.Events.QOE_AGGREGATE,
-      "kpi.totalPlaytime": 3000
+      totalPlaytime: 3000
     };
 
     videoAnalyticsHarvester.addEvent(qoeEvent1);
@@ -171,6 +171,61 @@ describe("QOE_AGGREGATE Buffer Management", () => {
 
     videoAnalyticsHarvester.addEvent(qoeEvent3);
     expect(videoAnalyticsHarvester.eventBuffer.totalEvents).toBe(1);
+  });
+
+  it("should always replace QOE_AGGREGATE in buffer (dedup happens at drain time in scheduler)", () => {
+    const qoeEvent1 = {
+      eventType: "VideoAction",
+      actionName: Tracker.Events.QOE_AGGREGATE,
+      totalPlaytime: 5000,
+      peakBitrate: 2000,
+      averageBitrate: 1500,
+      timestamp: 1000
+    };
+
+    const qoeEvent2 = {
+      eventType: "VideoAction",
+      actionName: Tracker.Events.QOE_AGGREGATE,
+      totalPlaytime: 5000,
+      peakBitrate: 2000,
+      averageBitrate: 1500,
+      timestamp: 2000
+    };
+
+    videoAnalyticsHarvester.addEvent(qoeEvent1);
+    expect(videoAnalyticsHarvester.eventBuffer.size()).toBe(1);
+
+    // Same KPIs, different timestamp — should replace (agent no longer does dirty check)
+    videoAnalyticsHarvester.addEvent(qoeEvent2);
+    expect(videoAnalyticsHarvester.eventBuffer.size()).toBe(1);
+
+    const events = videoAnalyticsHarvester.eventBuffer.drain();
+    // Should have the latest timestamp (replaced)
+    expect(events[0].timestamp).toBe(2000);
+  });
+
+  it("should replace QOE_AGGREGATE when KPIs change", () => {
+    const qoeEvent1 = {
+      eventType: "VideoAction",
+      actionName: Tracker.Events.QOE_AGGREGATE,
+      totalPlaytime: 5000,
+      peakBitrate: 2000
+    };
+
+    const qoeEvent2 = {
+      eventType: "VideoAction",
+      actionName: Tracker.Events.QOE_AGGREGATE,
+      totalPlaytime: 8000,
+      peakBitrate: 3000
+    };
+
+    videoAnalyticsHarvester.addEvent(qoeEvent1);
+    videoAnalyticsHarvester.addEvent(qoeEvent2);
+
+    expect(videoAnalyticsHarvester.eventBuffer.size()).toBe(1);
+    const events = videoAnalyticsHarvester.eventBuffer.drain();
+    expect(events[0].totalPlaytime).toBe(8000);
+    expect(events[0].peakBitrate).toBe(3000);
   });
 
 });

--- a/test/videotrackerstate.spec.js
+++ b/test/videotrackerstate.spec.js
@@ -290,8 +290,8 @@ describe("VideoTrackerState", () => {
       expect(state.startupTime).toBeNull();
       expect(state.peakBitrate).toBe(0);
       expect(state.partialAverageBitrate).toBe(0);
-      expect(state.hadStartupFailure).toBe(false);
-      expect(state.hadPlaybackFailure).toBe(false);
+      expect(state.hadStartupError).toBe(false);
+      expect(state.hadPlaybackError).toBe(false);
       expect(state.totalRebufferingTime).toBe(0);
     });
 
@@ -316,7 +316,8 @@ describe("VideoTrackerState", () => {
       expect(state.startupTime).toBe(0);
     });
 
-    it("should track peakBitrate correctly (max value over time)", () => {
+    it("should track peakBitrate correctly even when not playing", () => {
+      // peakBitrate updates regardless of play state
       state.trackContentBitrateState(1000);
       expect(state.peakBitrate).toBe(1000);
 
@@ -324,20 +325,99 @@ describe("VideoTrackerState", () => {
       expect(state.peakBitrate).toBe(1500);
 
       state.trackContentBitrateState(800);
-      expect(state.peakBitrate).toBe(1500); 
+      expect(state.peakBitrate).toBe(1500);
 
       state.trackContentBitrateState(2000);
       expect(state.peakBitrate).toBe(2000);
     });
 
-    it("should not set hadStartupFailure if error occurs after start", () => {
+    it("should compute time-weighted average bitrate only during play state", () => {
+      const dateNowSpy = jest.spyOn(Date, 'now');
+      let currentTime = 1000;
+      dateNowSpy.mockImplementation(() => currentTime);
+
+      // Simulate playing state
+      state.isPlaying = true;
+
+      // First bitrate observation at t=1000
+      state.trackContentBitrateState(2000000);
+      expect(state.peakBitrate).toBe(2000000);
+      expect(state.weightedBitrate).toBe(2000000); // First observation = bitrate itself
+
+      // Change bitrate at t=11000 (after 10s at 2Mbps)
+      currentTime = 11000;
+      state.trackContentBitrateState(4000000);
+
+      // Previous segment: 2Mbps * 10000ms = 20000000000
+      // New segment: just started, 0 duration
+      // Average = 20000000000 / 10000 = 2000000 (only the closed segment)
+      expect(state.peakBitrate).toBe(4000000);
+      // At the same instant of change, only the closed segment contributes
+      expect(state.weightedBitrate).toBe(2000000);
+
+      // Read at t=31000 (after 20s at 4Mbps)
+      currentTime = 31000;
+      state.trackContentBitrateState(4000000); // Same bitrate, no segment close
+
+      // Closed: 2M*10000 = 20000000000
+      // In-progress: 4M*20000 = 80000000000
+      // Total: 100000000000 / 30000 ≈ 3333333
+      expect(state.weightedBitrate).toBe(Math.round(100000000000 / 30000));
+
+      dateNowSpy.mockRestore();
+    });
+
+    it("should exclude buffering time from average bitrate calculation", () => {
+      const dateNowSpy = jest.spyOn(Date, 'now');
+      let currentTime = 1000;
+      dateNowSpy.mockImplementation(() => currentTime);
+
+      state.isPlaying = true;
+
+      // Play at 2Mbps for 10s
+      state.trackContentBitrateState(2000000);
+      currentTime = 11000;
+
+      // Buffer starts at t=11000 — closes play segment (10s at 2Mbps)
+      state.isPlaying = false;
+      state.trackContentBitrateState(2000000);
+
+      // Buffer for 5s (this time should NOT count)
+      currentTime = 16000;
+
+      // Resume playing at t=16000 — restarts segment
+      state.isPlaying = true;
+
+      // Play at 4Mbps for 10s
+      state.trackContentBitrateState(4000000);
+      currentTime = 26000;
+      state.trackContentBitrateState(4000000);
+
+      // Only play time: 2M*10000 + 4M*10000 = 60000000000 / 20000 = 3000000
+      // Buffer time (5s) is excluded
+      expect(state.weightedBitrate).toBe(3000000);
+
+      dateNowSpy.mockRestore();
+    });
+
+    it("should initialize _totalBitrateDuration to 0", () => {
+      expect(state._totalBitrateDuration).toBe(0);
+    });
+
+    it("should reset _totalBitrateDuration in resetViewIdTrackedState", () => {
+      state._totalBitrateDuration = 5000;
+      state.resetViewIdTrackedState();
+      expect(state._totalBitrateDuration).toBe(0);
+    });
+
+    it("should not set hadStartupError if error occurs after start", () => {
       state.goRequest();
       state.goStart();
       expect(state.isStarted).toBe(true);
 
       state.goError();
-      expect(state.hadStartupFailure).toBe(false);
-      expect(state.hadPlaybackFailure).toBe(true);
+      expect(state.hadStartupError).toBe(false);
+      expect(state.hadPlaybackError).toBe(true);
     });
 
     it("getQoeAttributes() should return all KPI attributes with correct structure", () => {
@@ -348,8 +428,8 @@ describe("VideoTrackerState", () => {
       state.peakBitrate = 2000;
       state.partialAverageBitrate = 6000;
       state.weightedBitrate = 1200; // Set the weighted bitrate that will be used in averageBitrate
-      state.hadStartupFailure = false;
-      state.hadPlaybackFailure = true;
+      state.hadStartupError = false;
+      state.hadPlaybackError = true;
       state.totalRebufferingTime = 300;
       state.totalPlaytime = 5000;
       state.numberOfErrors = 3;
@@ -361,8 +441,8 @@ describe("VideoTrackerState", () => {
       expect(typeof result.qoe).toBe("object");
       expect(qoeAttrs["startupTime"]).toBe(500);
       expect(qoeAttrs["peakBitrate"]).toBe(2000);
-      expect(qoeAttrs["hadStartupFailure"]).toBe(false);
-      expect(qoeAttrs["hadPlaybackFailure"]).toBe(true);
+      expect(qoeAttrs["hadStartupError"]).toBe(false);
+      expect(qoeAttrs["hadPlaybackError"]).toBe(true);
       expect(qoeAttrs["totalRebufferingTime"]).toBe(300);
       expect(qoeAttrs["rebufferingRatio"]).toBeCloseTo(6, 0);
       expect(qoeAttrs["totalPlaytime"]).toBe(5000);


### PR DESCRIPTION
# fix: QoE Aggregate — KPI Accuracy, Harvest Lifecycle & Dedup

## What & Why

QoE aggregate events had several bugs: wrong KPI values, events getting lost during harvest, stale data at send time, and duplicate sends. This PR fixes all of them.

## Bug Fixes

### KPI Calculations

| Bug | What went wrong | Fix |
|-----|----------------|-----|
| **Startup time wrong with multiple pre-roll ads** | Only counted the current ad's time, ignored previous ads | Sum all ad time before content start |
| **Average bitrate always showed latest value** | Math cancelled itself out — wasn't actually averaging | Weighted average based on how long each bitrate played (excludes buffering/pause) |
| **Rebuffering time drifted** | Timer kept ticking after buffering stopped | Use the exact duration captured when buffering ended |

### Harvest Lifecycle

| Bug | What went wrong | Fix |
|-----|----------------|-----|
| **QoE events lost between cycles** | Non-QoE harvest cycles drained QoE from buffer and threw it away | Keep QoE in buffer until a QoE-eligible cycle picks it up |
| **Stale KPIs at send time** | QoE snapshot could be seconds old by the time it was sent | Refresh KPIs from live tracker state right before each drain |
| **QoE missing at content end** | Content end could land on a non-QoE cycle | Force the next cycle to include QoE |
| **Duplicate QoE sent across cycles** | No comparison between cycles — same data sent repeatedly | Skip sending if KPIs haven't changed since last send. Always send at content end and page unload |

## How QoE flows through the system

```
1. Video plays → tracker state continuously updates KPIs
2. Every video action → QoE event added to buffer (one slot, always replaced with latest)
3. Harvest timer fires:
   a. Refresh KPIs from live state
   b. Drain buffer
   c. Is this a QoE cycle?
      NO  → put QoE back in buffer for later
      YES → KPIs changed since last send? → send or skip
4. Content end → force send QoE, stop refreshing, reset for next view
```

## Cleanup

- Renamed `hadStartupFailure` → `hadStartupError` (matches backend)
- `console.log` → `Log.debug`
- Custom attributes excluded from QoE events
- KPI keys centralised in `Constants.QOE_KPI_KEYS`
- String constants used instead of hardcoded values

## Files Changed

| File | Changes |
|------|---------|
| `src/videotracker.js` | Startup time fix, force QoE at content end, register/clear pre-drain callback |
| `src/videotrackerstate.js` | Weighted avg bitrate, precise rebuffering time, rename error attrs |
| `src/harvestScheduler.js` | Keep QoE on non-QoE cycles, pre-drain refresh, cross-cycle dedup |
| `src/agent.js` | Force QoE cycle, pre-drain callback, KPI refresh helpers |
| `src/eventAggregator.js` | `findByActionName()` helper |
| `src/constants.js` | `QOE_KPI_KEYS` array |
| `src/recordEvent.js` | Builds QoE from whitelisted keys only |