### PR TITLE
feat: NR-538889 Add obfuscation rules support for pre-harvest payload…

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,22 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm test)",
+      "Bash(npm test:*)",
+      "Bash(node --version)",
+      "Bash(npm --version:*)",
+      "Bash(npm pack:*)",
+      "Bash(cat:*)",
+      "Bash(npm view:*)",
+      "Bash(git log:*)",
+      "Bash(tar:*)",
+      "Bash(md5sum:*)",
+      "Bash(node:*)",
+      "Bash(git stash:*)",
+      "Bash(git checkout:*)",
+      "Bash(npm run build:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/README.md
+++ b/README.md
@@ -34,6 +34,73 @@ const tracker = new VideoSpecificTracker(player, options);
 
 - **qoeIntervalFactor** (number, optional, default: `1`): Controls how frequently QoE aggregate events are included in harvest cycles. A value of `1` includes them on every cycle; a value of `N` includes them once every N cycles. Must be a positive integer — invalid values default to `1`. QoE events are always included on the first and final harvest cycles regardless of this setting.
 
+- **obfuscate** (array, optional): A list of regex-based obfuscation rules applied to event payloads before they are sent to the New Relic collector. See [Obfuscation Rules](#obfuscation-rules) below.
+
+
+## Obfuscation Rules
+
+Video trackers can capture rich telemetry (content URLs, titles, ad metadata, etc.) that may inadvertently contain PII or sensitive tokens. The `obfuscate` config option lets you define regex-based rules that mask sensitive data in the serialized event payload **before** it is sent to the New Relic collector.
+
+This matches the approach used by the New Relic Browser Agent.
+
+### Configuration
+
+Pass an `obfuscate` array in the `config` parameter of `setVideoConfig` (or the tracker options). Each rule must have:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `regex` | `string` \| `RegExp` | Pattern to match in the serialized payload |
+| `replacement` | `string` | String to replace each match with |
+
+```javascript
+const options = {
+  info: {
+    licenseKey: "xxxxxxxxxxx",
+    beacon: "xxxxxxxxxx",
+    applicationId: "xxxxxxx",
+  },
+  config: {
+    obfuscate: [
+      { regex: /\/user\/\d+/, replacement: "/user/[REDACTED]" },
+    ],
+  },
+};
+
+const tracker = new VideoSpecificTracker(player, options);
+```
+
+### Examples
+
+**Mask user IDs in content URLs:**
+
+```javascript
+obfuscate: [
+  { regex: /\/user\/[^\/?"]+/, replacement: "/user/[REDACTED]" }
+]
+// "https://cdn.example.com/user/john.doe/video.mp4"
+// → "https://cdn.example.com/user/[REDACTED]/video.mp4"
+```
+
+**Mask auth tokens in query strings:**
+
+```javascript
+obfuscate: [
+  { regex: /token=[^&"]+/, replacement: "token=[MASKED]" }
+]
+// "https://cdn.example.com/stream.m3u8?token=eyJhbGci..."
+// → "https://cdn.example.com/stream.m3u8?token=[MASKED]"
+```
+
+### Rule ordering
+
+Rules are applied in array order. The output of one rule is the input for the next, so ordering matters when rules overlap.
+
+### Edge cases
+
+- **Invalid regex**: The rule is skipped and a warning is logged via `Log.warn`. Other rules continue to apply normally.
+- **Empty replacement**: Setting `replacement: ""` deletes the matched content entirely.
+- **RegExp flags**: The global flag (`g`) is always applied so all occurrences in the payload are replaced. Other flags (`i`, `m`, etc.) on `RegExp` objects are preserved.
+
 
 ## APIs
 

--- a/src/obfuscate.js
+++ b/src/obfuscate.js
@@ -1,0 +1,33 @@
+import Log from "./log";
+
+/**
+ * Applies obfuscation rules to a JSON string before sending to the collector.
+ * Each rule replaces matches of `regex` with `replacement` in the string.
+ *
+ * @param {string} jsonString - Serialized JSON payload
+ * @param {Array<{regex: string|RegExp, replacement: string}>} rules - Obfuscation rules
+ * @returns {string} Obfuscated string
+ */
+export function applyObfuscationRules(jsonString, rules) {
+  if (!rules || rules.length === 0) return jsonString;
+
+  return rules.reduce((str, rule) => {
+    let pattern;
+    try {
+      if (rule.regex instanceof RegExp) {
+        // Ensure global flag so all occurrences are replaced
+        const flags = rule.regex.flags.includes("g")
+          ? rule.regex.flags
+          : rule.regex.flags + "g";
+        pattern = new RegExp(rule.regex.source, flags);
+      } else {
+        pattern = new RegExp(rule.regex, "g");
+      }
+    } catch (e) {
+      Log.warn("applyObfuscationRules: invalid regex, skipping rule:", rule.regex, e.message);
+      return str;
+    }
+    let s = str.replace(pattern, rule.replacement);
+    return s;
+  }, jsonString);
+}

--- a/src/optimizedHttpClient.js
+++ b/src/optimizedHttpClient.js
@@ -1,5 +1,6 @@
-import { dataSize, shouldRetry } from "./utils";
+import { shouldRetry } from "./utils";
 import Log from "./log";
+import { applyObfuscationRules } from "./obfuscate";
 
 /**
  * Optimized HTTP client for video analytics data transmission with
@@ -50,7 +51,10 @@ export class OptimizedHttpClient {
     const startTime = Date.now();
 
     try {
-      const requestBody = JSON.stringify(payload.body);
+      const requestBody = applyObfuscationRules(
+        JSON.stringify(payload.body),
+        window.NRVIDEO?.config?.obfuscate
+      );
 
       // Handle final harvest with sendBeacon
       if (options.isFinalHarvest && navigator.sendBeacon) {

--- a/src/videoConfiguration.js
+++ b/src/videoConfiguration.js
@@ -92,14 +92,37 @@ class VideoConfiguration {
       return false;
     }
 
-    const { qoeAggregate } = config;
+    const { qoeAggregate, obfuscate } = config;
 
     if (qoeAggregate !== undefined && typeof qoeAggregate !== "boolean") {
       Log.error("qoeAggregate must be a boolean");
       return false;
     }
 
+    if (obfuscate !== undefined && !Array.isArray(obfuscate)) {
+      Log.error("obfuscate must be an array");
+      return false;
+    }
+
     return true;
+  }
+
+  /**
+   * Filters obfuscation rules, warning about and removing invalid ones.
+   * @param {Array} rules - Raw obfuscation rules
+   * @returns {Array} Valid rules only
+   */
+  filterObfuscateRules(rules) {
+    if (!rules) return [];
+    return rules.filter((rule) => {
+      const hasRegex = rule.regex !== undefined && (typeof rule.regex === "string" || rule.regex instanceof RegExp);
+      const hasReplacement = rule.replacement !== undefined && typeof rule.replacement === "string";
+      if (!hasRegex || !hasReplacement) {
+        Log.warn("obfuscate rule missing required 'regex' (string|RegExp) and/or 'replacement' (string), skipping:", rule);
+        return false;
+      }
+      return true;
+    });
   }
 
   /**
@@ -141,6 +164,7 @@ class VideoConfiguration {
       config: {
         qoeAggregate: config?.qoeAggregate ?? false,
         qoeIntervalFactor: this.sanitizeQoeIntervalFactor(config?.qoeIntervalFactor),
+        obfuscate: this.filterObfuscateRules(config?.obfuscate),
       }
     };
   }

--- a/test/obfuscate.spec.js
+++ b/test/obfuscate.spec.js
@@ -1,0 +1,91 @@
+import sinon from 'sinon';
+import { applyObfuscationRules } from '../src/obfuscate';
+import Log from '../src/log';
+
+describe('applyObfuscationRules', function () {
+  beforeAll(function () {
+    Log.level = Log.Levels.SILENT;
+  });
+
+  afterAll(function () {
+    Log.level = Log.Levels.ERROR;
+  });
+
+  it('returns input unchanged when rules is undefined', function () {
+    const input = '{"contentSrc":"https://example.com/video.mp4"}';
+    expect(applyObfuscationRules(input, undefined)).toBe(input);
+  });
+
+  it('returns input unchanged when rules is null', function () {
+    const input = '{"contentSrc":"https://example.com/video.mp4"}';
+    expect(applyObfuscationRules(input, null)).toBe(input);
+  });
+
+  it('returns input unchanged when rules is an empty array', function () {
+    const input = '{"contentSrc":"https://example.com/video.mp4"}';
+    expect(applyObfuscationRules(input, [])).toBe(input);
+  });
+
+  it('applies a single string pattern rule', function () {
+    const input = '{"token":"secret-abc123","event":"CONTENT_START"}';
+    const rules = [{ regex: 'secret-[a-z0-9]+', replacement: '***' }];
+    expect(applyObfuscationRules(input, rules)).toBe('{"token":"***","event":"CONTENT_START"}');
+  });
+
+  it('applies a RegExp object rule', function () {
+    const input = '{"contentSrc":"https://cdn.example.com/user/12345/video.mp4"}';
+    const rules = [{ regex: /\/user\/\d+/, replacement: '/user/[REDACTED]' }];
+    expect(applyObfuscationRules(input, rules)).toBe('{"contentSrc":"https://cdn.example.com/user/[REDACTED]/video.mp4"}');
+  });
+
+  it('applies multiple rules in order', function () {
+    const input = '{"token":"secret-abc","accountId":"acct-999","event":"START"}';
+    const rules = [
+      { regex: 'secret-[a-z]+', replacement: '[TOKEN]' },
+      { regex: 'acct-\\d+', replacement: '[ACCOUNT]' },
+    ];
+    const result = applyObfuscationRules(input, rules);
+    expect(result).toBe('{"token":"[TOKEN]","accountId":"[ACCOUNT]","event":"START"}');
+  });
+
+  it('replaces all occurrences in the string', function () {
+    const input = '{"a":"secret-x","b":"secret-y"}';
+    const rules = [{ regex: 'secret-[a-z]', replacement: 'REDACTED' }];
+    expect(applyObfuscationRules(input, rules)).toBe('{"a":"REDACTED","b":"REDACTED"}');
+  });
+
+  it('deletes matched content when replacement is an empty string', function () {
+    const input = '{"contentSrc":"https://example.com?token=abc123"}';
+    const rules = [{ regex: '\\?token=[^"]+', replacement: '' }];
+    expect(applyObfuscationRules(input, rules)).toBe('{"contentSrc":"https://example.com"}');
+  });
+
+  it('logs a warning and skips invalid regex, continuing with remaining rules', function () {
+    const warnSpy = sinon.spy(Log, 'warn');
+    const input = '{"token":"secret-abc","accountId":"acct-999"}';
+    const rules = [
+      { regex: '[invalid(regex', replacement: 'SKIP' },
+      { regex: 'acct-\\d+', replacement: '[ACCOUNT]' },
+    ];
+
+    const result = applyObfuscationRules(input, rules);
+
+    expect(warnSpy.calledOnce).toBe(true);
+    expect(result).toBe('{"token":"secret-abc","accountId":"[ACCOUNT]"}');
+
+    warnSpy.restore();
+  });
+
+  it('supports RegExp objects that already have the global flag', function () {
+    const input = '{"a":"tok-1","b":"tok-2"}';
+    const rules = [{ regex: /tok-\d/g, replacement: 'X' }];
+    expect(applyObfuscationRules(input, rules)).toBe('{"a":"X","b":"X"}');
+  });
+
+  it('supports RegExp objects without global flag (adds it automatically)', function () {
+    const input = '{"a":"tok-1","b":"tok-2"}';
+    // No global flag — should still replace all occurrences
+    const rules = [{ regex: /tok-\d/, replacement: 'X' }];
+    expect(applyObfuscationRules(input, rules)).toBe('{"a":"X","b":"X"}');
+  });
+});


### PR DESCRIPTION
<img width="582" height="683" alt="Screenshot 2026-03-24 at 12 00 19" src="https://github.com/user-attachments/assets/5e69fd91-3a44-4cc5-b222-5cbb99a31110" />


config setting in videojs:
```
      const options = {
        info: {
        },
        config: {
          obfuscate: [
            { regex: /https:\/\/[^\s"']+/, replacement: "[redacted]" },
          ],
        },
      };

```