### PR TITLE
feat: Removed fallback of bitrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [4.1.3] - 2026/03/24
+
+### Fix
+
+- **Bitrate attributes default to 0 instead of null**
+  Updated `getAttributes()` in `videotracker.js` to fallback bitrate values (`contentBitrate`, `contentRenditionBitrate`, `contentManifestBitrate`, `contentMeasuredBitrate`, `contentDownloadBitrate`) to `0` when null, preventing attributes from being dropped by `cleanData`.
+
 ## [4.1.2] - 2026/03/18
 
 ### Fix

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/video-core",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "New Relic video tracking core library",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/src/videotracker.js
+++ b/src/videotracker.js
@@ -485,10 +485,8 @@ class VideoTracker extends Tracker {
       // Only add bitrate attributes after ad has started
       if (this.state.isStarted) {
         att.adBitrate =
-          this.getBitrate() ||
-          this.getWebkitBitrate() ||
-          this.getRenditionBitrate();
-        att.adRenditionBitrate = this.getRenditionBitrate();
+          this.getBitrate() || 0;
+        att.adRenditionBitrate = this.getRenditionBitrate() || 0;
       }
 
       att.adRenditionName = this.getRenditionName();
@@ -516,14 +514,11 @@ class VideoTracker extends Tracker {
 
       // Only add bitrate attributes after content has started
       if (this.state.isStarted) {
-        att.contentBitrate =
-          this.getBitrate() ||
-          this.getWebkitBitrate() ||
-          this.getRenditionBitrate();
-        att.contentRenditionBitrate = this.getRenditionBitrate();
-        att.contentManifestBitrate = this.getManifestBitrate();
-        att.contentMeasuredBitrate = this.getMeasuredBitrate();
-        att.contentDownloadBitrate = this.getDownloadBitrate();
+        att.contentBitrate = this.getBitrate()|| 0;
+        att.contentRenditionBitrate = this.getRenditionBitrate() || 0;
+        att.contentManifestBitrate = this.getManifestBitrate() || 0;
+        att.contentMeasuredBitrate = this.getMeasuredBitrate() || 0;
+        att.contentDownloadBitrate = this.getDownloadBitrate() || 0;
       }
 
       att.contentRenditionName = this.getRenditionName();


### PR DESCRIPTION
## Summary

- Removed the multi-method fallback chain for bitrate attributes in `getAttributes()` within `videotracker.js`
- Each bitrate attribute now only calls its dedicated getter, falling back to `0` instead of cascading through other getter methods
- Applies to both **ad** and **content** bitrate attributes

## Changes

### `src/videotracker.js`

**Ad attributes (`adBitrate`, `adRenditionBitrate`)**

Before:
```js
att.adBitrate = this.getBitrate() || this.getWebkitBitrate() || this.getRenditionBitrate();
att.adRenditionBitrate = this.getRenditionBitrate();
```

After:
```js
att.adBitrate = this.getBitrate() || 0;
att.adRenditionBitrate = this.getRenditionBitrate() || 0;
```

**Content attributes (`contentBitrate`, `contentRenditionBitrate`, `contentManifestBitrate`, `contentMeasuredBitrate`, `contentDownloadBitrate`)**

Before:
```js
att.contentBitrate = this.getBitrate() || this.getWebkitBitrate() || this.getRenditionBitrate();
att.contentRenditionBitrate = this.getRenditionBitrate();
att.contentManifestBitrate = this.getManifestBitrate();
att.contentMeasuredBitrate = this.getMeasuredBitrate();
att.contentDownloadBitrate = this.getDownloadBitrate();
```

After:
```js
att.contentBitrate = this.getBitrate() || 0;
att.contentRenditionBitrate = this.getRenditionBitrate() || 0;
att.contentManifestBitrate = this.getManifestBitrate() || 0;
att.contentMeasuredBitrate = this.getMeasuredBitrate() || 0;
att.contentDownloadBitrate = this.getDownloadBitrate() || 0;
```

## Motivation

The previous fallback chain (`getBitrate() || getWebkitBitrate() || getRenditionBitrate()`) caused `contentBitrate` and `adBitrate` to silently use a different bitrate source when the primary getter returned a falsy value. This led to inaccurate or misleading bitrate data.

Each bitrate attribute now strictly reflects its own source, with `0` as the explicit default to ensure the attribute is always present and not dropped by `cleanData`.