### PR TITLE
feat: add JP (Japan) region to COLLECTOR constants

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -25,6 +25,7 @@ Constants.AdPositions = {
 Constants.COLLECTOR = {
   US: ["bam.nr-data.net", "bam-cell.nr-data.net"],
   EU: "bam.eu01.nr-data.net",
+  JP: "bam.jp.nr-data.net",
   Staging: "staging-bam-cell.nr-data.net",
   GOV: "gov-bam.nr-data.net",
 };


### PR DESCRIPTION
## Summary

- Add `JP: "bam.jp.nr-data.net"` to `Constants.COLLECTOR` in `src/constants.js`
- Enables JP region routing for browser agents — `COLLECTOR["JP"]` now resolves to the confirmed JP BAM endpoint
- The existing `COLLECTOR[region]` lookup in `videoConfiguration.js` picks this up automatically — no further code changes needed

## Test plan

- [ ] Pass `region: "JP"` in `setVideoConfig()` — verify beacon is set to `bam.jp.nr-data.net`
- [ ] Verify the region validation (`COLLECTOR[region]` check) passes for `"JP"`
- [ ] Confirm existing US, EU, GOV, and Staging regions are unaffected