### PR TITLE
feat: enable QoE by default with interval multiplier 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,8 @@ info: {
 
 | Option | Type | Default | Description |
 |---|---|---|---|
-| `qoeAggregate` | `boolean` | `false` | Enable Quality of Experience event aggregation. |
-| `qoeIntervalFactor` | `number` | `1` | Include QoE aggregate events once every N harvest cycles. Must be a positive integer. QoE events are always sent on the first and final harvest cycles. |
+| `qoeAggregate` | `boolean` | `true` | Enable Quality of Experience event aggregation. QoE is enabled out of the box; set to `false` to disable. |
+| `qoeIntervalFactor` | `number` | `2` | Include QoE aggregate events once every N harvest cycles. Must be a positive integer. QoE events are always sent on the first and final harvest cycles. |
 | `obfuscate` | `array` | `[]` | Regex-based rules to mask sensitive data before transmission. See [Obfuscation Rules](#obfuscation-rules). |
 
 ---
@@ -409,7 +409,7 @@ These methods return `null` by default. Override them in your tracker to provide
 
 ## Quality of Experience (QoE)
 
-When `qoeAggregate` is enabled, the library tracks and reports QoE KPI metrics as `QOE_AGGREGATE` events:
+QoE tracking is **enabled by default**. The library tracks and reports QoE KPI metrics as `QOE_AGGREGATE` events. To disable, set `qoeAggregate: false` in the config object. The harvest interval multiplier can be configured via `qoeIntervalFactor` (default: `2`).
 
 | KPI | Description |
 |---|---|

--- a/src/videoConfiguration.js
+++ b/src/videoConfiguration.js
@@ -133,7 +133,7 @@ class VideoConfiguration {
   sanitizeQoeIntervalFactor(value) {
     if (value === undefined || value === null) return 2;
     if (typeof value === "number" && Number.isInteger(value) && value >= 1) return value;
-    console.warn(`[nrvideo] Invalid qoeIntervalFactor "${value}" — must be a positive integer. Defaulting to 2.`);
+    Log.warn(`Invalid qoeIntervalFactor "${value}" — must be a positive integer. Defaulting to 2.`);
     return 2;
   }
 

--- a/src/videoConfiguration.js
+++ b/src/videoConfiguration.js
@@ -126,15 +126,15 @@ class VideoConfiguration {
   }
 
   /**
-   * Sanitizes qoeIntervalFactor, defaulting to 1 if the value is not a positive integer.
+   * Sanitizes qoeIntervalFactor, defaulting to 2 if the value is not a positive integer.
    * @param {*} value
    * @returns {number}
    */
   sanitizeQoeIntervalFactor(value) {
-    if (value === undefined || value === null) return 1;
+    if (value === undefined || value === null) return 2;
     if (typeof value === "number" && Number.isInteger(value) && value >= 1) return value;
-    console.warn(`[nrvideo] Invalid qoeIntervalFactor "${value}" — must be a positive integer. Defaulting to 1.`);
-    return 1;
+    console.warn(`[nrvideo] Invalid qoeIntervalFactor "${value}" — must be a positive integer. Defaulting to 2.`);
+    return 2;
   }
 
   /**
@@ -162,7 +162,7 @@ class VideoConfiguration {
         ...(applicationID ? {} : { appName }), // Only include appName when no applicationID
       },
       config: {
-        qoeAggregate: config?.qoeAggregate ?? false,
+        qoeAggregate: config?.qoeAggregate ?? true,
         qoeIntervalFactor: this.sanitizeQoeIntervalFactor(config?.qoeIntervalFactor),
         obfuscate: this.filterObfuscateRules(config?.obfuscate),
       }

--- a/test/videoConfiguration.spec.js
+++ b/test/videoConfiguration.spec.js
@@ -192,7 +192,7 @@ describe('videoConfiguration', function() {
         expect(global.window.NRVIDEO.config.qoeAggregate).toBe(false);
       });
 
-      it('should default qoeAggregate to false when config is undefined', function() {
+      it('should default qoeAggregate to true when config is undefined', function() {
         const info = {
           licenseKey: 'test-key',
           appName: 'MyApp',
@@ -202,10 +202,10 @@ describe('videoConfiguration', function() {
         const result = setVideoConfig(info);
 
         expect(result).toBe(true);
-        expect(global.window.NRVIDEO.config.qoeAggregate).toBe(false);
+        expect(global.window.NRVIDEO.config.qoeAggregate).toBe(true);
       });
 
-      it('should default qoeAggregate to false when config is null', function() {
+      it('should default qoeAggregate to true when config is null', function() {
         const info = {
           licenseKey: 'test-key',
           appName: 'MyApp',
@@ -215,10 +215,10 @@ describe('videoConfiguration', function() {
         const result = setVideoConfig(info, null);
 
         expect(result).toBe(true);
-        expect(global.window.NRVIDEO.config.qoeAggregate).toBe(false);
+        expect(global.window.NRVIDEO.config.qoeAggregate).toBe(true);
       });
 
-      it('should default qoeAggregate to false when qoeAggregate is undefined in config', function() {
+      it('should default qoeAggregate to true when qoeAggregate is undefined in config', function() {
         const info = {
           licenseKey: 'test-key',
           appName: 'MyApp',
@@ -229,7 +229,7 @@ describe('videoConfiguration', function() {
         const result = setVideoConfig(info, config);
 
         expect(result).toBe(true);
-        expect(global.window.NRVIDEO.config.qoeAggregate).toBe(false);
+        expect(global.window.NRVIDEO.config.qoeAggregate).toBe(true);
       });
 
       it('should reject config when it is not an object', function() {


### PR DESCRIPTION
Enables QoE tracking by default and sets the interval multiplier default to 2. Part of NR-573376.