### PR TITLE
fix: upgrade shared mock stubs to jest.fn() for call-count assertions

### DIFF
--- a/__mock__.js
+++ b/__mock__.js
@@ -25,8 +25,7 @@
  * - This mock is ONLY for testing purposes
  * - It provides the minimal interface needed for Jest-based unit tests
  * - It is NOT included in the built dist/ bundles
- * - Function stubs are intentionally simple (no jest.fn() or sinon) to remain framework-agnostic
- * - Consumer tests can override these stubs with their own mocks/spies as needed
+ * - All consumers use Jest; stubs use jest.fn() to support call-count assertions
  */
 
 const nrvideo = {
@@ -65,7 +64,7 @@ const nrvideo = {
    * Handles tracker registration and management
    */
   Core: {
-    addTracker: function() {}
+    addTracker: jest.fn(),
   },
 
   /**
@@ -73,7 +72,12 @@ const nrvideo = {
    * Handles debug logging
    */
   Log: {
-    debugCommonVideoEvents: function() {}
+    debugCommonVideoEvents: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    notice: jest.fn(),
   }
 };
 


### PR DESCRIPTION
## Summary

- `Core.addTracker` and all `Log` methods (`debugCommonVideoEvents`, `warn`, `debug`, `error`, `info`, `notice`) upgraded from plain `function(){}` stubs to `jest.fn()`
- Removes the "framework-agnostic" comment restriction — all consumers use Jest

## Why

Consumer tests (e.g. `video-videojs-js` [#125](https://github.com/newrelic/video-videojs-js/pull/125)) assert `expect(Log.warn).toHaveBeenCalled()`. Plain function stubs throw `Log.warn is not a function` (missing methods) and don't support call-count assertions.

## Test plan

- [ ] Existing video-core-js tests pass
- [ ] Consumer repos using `moduleNameMapper: { '^@newrelic/video-core$': '@newrelic/video-core/__mock__.js' }` can assert on `Log.warn`, `Log.error`, etc.