### PR TITLE
docs: add harvest cycle configuration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,19 @@ Base class for video player trackers. Extends `Tracker`.
 | `unregisterListeners()` | **Override this.** Detach player event listeners. |
 | `getAttributes(att)` | **Do NOT override.** Collects all video/ad attributes. Use getter methods instead. |
 
+### Live Stream Configuration
+
+**Recommendations for Live Content:**
+
+For live streams, reduce the harvest interval to 5,000–10,000 ms for near-real-time data delivery:
+
+```javascript
+// Live content — flush every 5 seconds
+tracker.setHarvestInterval(5000)
+
+// VOD content — default 10s is sufficient or change it as required
+```
+
 **State-changing methods** (call these from `registerListeners`):
 
 | Method | Event Emitted (Content / Ad) | Description |


### PR DESCRIPTION
Adds `### Live Stream Configuration` section to README.md.

Part of [PRD: Harvest Cycle Configuration Documentation](https://newrelic.atlassian.net/wiki/spaces/VERTSOL/pages/5952111079/PRD+Harvest+Cycle+Configuration+Documentation).